### PR TITLE
feat(disciplina-usp): melhorias de normalização, tratamento, filtrage…

### DIFF
--- a/resources/views/partials/disciplina-usp.blade.php
+++ b/resources/views/partials/disciplina-usp.blade.php
@@ -25,6 +25,6 @@
         selector: '#{{ $field['id'] }}',
         url: '{{ route('form.find.disciplina') }}',
         placeholder: 'Selecione uma disciplina...',
-        minimumInputLength: 3,
+        minimumInputLength: 1,
     });
 </script>

--- a/src/Http/Controllers/FindController.php
+++ b/src/Http/Controllers/FindController.php
@@ -3,8 +3,8 @@ namespace Uspdev\Forms\Http\Controllers;
 
 use Illuminate\Http\Request;
 use Illuminate\Support\Str;
-use Uspdev\Forms\Replicado\Graduacao;
 use Uspdev\Forms\Replicado\Bempatrimoniado;
+use Uspdev\Forms\Replicado\Graduacao;
 use Uspdev\Replicado\Estrutura;
 use Uspdev\Replicado\Pessoa;
 
@@ -17,24 +17,35 @@ class FindController extends Controller
     {
         $this->authorize(config('uspdev-forms.findGate'));
 
-        if (! $request->term) {
-            return response([]);
+        $term = Str::upper(trim((string) $request->query('term', '')));
+
+        if (! preg_match('/^[A-Z0-9]+$/', $term)) {
+            return response()->json(['results' => []]);
         }
 
-        $results = [];
+        if (! hasReplicado()) {
+            return response()->json(['results' => []]);
+        }
 
-        if (hasReplicado()) {
-            $coddis = Str::upper($request->term);
+        try {
+            $results = collect(Graduacao::procurarDisciplinas($term, 50))
+                ->filter(fn ($disciplina) => is_array($disciplina)
+                    && isset($disciplina['coddis'], $disciplina['nomdis']))
+                ->map(fn (array $disciplina) => [
+                    'id' => trim((string) $disciplina['coddis']),
+                    'text' => trim((string) $disciplina['coddis'])
+                        . ' - '
+                        . trim((string) $disciplina['nomdis']),
+                ])
+                ->values()
+                ->all();
+        } catch (\Throwable $exception) {
+            logger()->error('Falha ao pesquisar disciplinas USP no Replicado.', [
+                'exception' => $exception,
+                'term' => $term,
+            ]);
 
-            $disciplinas = Graduacao::procurarDisciplinas($coddis, 50);
-
-            foreach ($disciplinas as $disciplina) {
-                $results[] = [
-                    'text' => $disciplina['coddis'] . ' - ' . $disciplina['nomdis'],
-                    'id'   => $disciplina['coddis'],
-                ];
-            }
-            $results = array_slice($results, 0, 50);
+            return response()->json(['results' => []], 503);
         }
 
         return response()->json(['results' => $results]);

--- a/src/Replicado/Graduacao.php
+++ b/src/Replicado/Graduacao.php
@@ -17,7 +17,7 @@ class Graduacao extends GraduacaoReplicado
      * @param int|null $limit
      * @return array
      */
-    public static function procurarDisciplinas($coddis, $limit = null)
+    public static function procurarDisciplinas($coddis, $limit = 50)
     {
         $coddis = Str::upper(trim((string) $coddis));
 
@@ -25,11 +25,8 @@ class Graduacao extends GraduacaoReplicado
             return [];
         }
 
-        $queryLimit = '';
-        if ($limit !== null) {
-            $limit = max(1, min((int) $limit, 50));
-            $queryLimit = "OFFSET 0 ROWS FETCH NEXT {$limit} ROWS ONLY";
-        }
+        $limit = $limit === null ? 50 : max(1, min((int) $limit, 50));
+        $queryLimit = "OFFSET 0 ROWS FETCH NEXT {$limit} ROWS ONLY";
 
         $query = "SELECT D1.*
                     FROM DISCIPLINAGR D1

--- a/src/Replicado/Graduacao.php
+++ b/src/Replicado/Graduacao.php
@@ -14,10 +14,10 @@ class Graduacao extends GraduacaoReplicado
      * Derivado de Uspdev\Replicado\Graduacao::obterDisciplinas.
      *
      * @param string $coddis
-     * @param int|null $limit
+     * @param int $limit
      * @return array
      */
-    public static function procurarDisciplinas($coddis, $limit = 50)
+    public static function procurarDisciplinas($coddis, int $limit = 50)
     {
         $coddis = Str::upper(trim((string) $coddis));
 
@@ -25,7 +25,7 @@ class Graduacao extends GraduacaoReplicado
             return [];
         }
 
-        $limit = $limit === null ? 50 : max(1, min((int) $limit, 50));
+        $limit = max(1, min($limit, 50));
         $queryLimit = "OFFSET 0 ROWS FETCH NEXT {$limit} ROWS ONLY";
 
         $query = "SELECT D1.*

--- a/src/Replicado/Graduacao.php
+++ b/src/Replicado/Graduacao.php
@@ -40,8 +40,6 @@ class Graduacao extends GraduacaoReplicado
                     ORDER BY D1.coddis ASC
         ";
 
-        $disciplinas = DB::fetchAll($query, ['coddis' => $coddis . '%']);
-
-        return is_array($disciplinas) ? $disciplinas : [];
+        return DB::fetchAll($query, ['coddis' => $coddis . '%']);
     }
 }

--- a/src/Replicado/Graduacao.php
+++ b/src/Replicado/Graduacao.php
@@ -2,24 +2,34 @@
 
 namespace Uspdev\Forms\Replicado;
 
+use Illuminate\Support\Str;
 use Uspdev\Replicado\DB;
 use Uspdev\Replicado\Graduacao as GraduacaoReplicado;
 
 class Graduacao extends GraduacaoReplicado
 {
-    /*
-    * Método para procurar disciplinas ativas de graduação por coddis
-    *
-    * Derivado do método Uspdev\Replicado\Graduacao::obterDisciplinas
-    * Adicionado verificação de disciplina ativa e limite de disciplinas
-    *
-    * @param String $coddis
-    * @param int $limit
-    * @return array()
-    */
+    /**
+     * Procura disciplinas ativas de graduação pelo início do código.
+     *
+     * Derivado de Uspdev\Replicado\Graduacao::obterDisciplinas.
+     *
+     * @param string $coddis
+     * @param int|null $limit
+     * @return array
+     */
     public static function procurarDisciplinas($coddis, $limit = null)
     {
-        $queryLimit = ($limit) ? "OFFSET 0 ROWS FETCH NEXT $limit ROWS ONLY" : '';
+        $coddis = Str::upper(trim((string) $coddis));
+
+        if (! preg_match('/^[A-Z0-9]+$/', $coddis)) {
+            return [];
+        }
+
+        $queryLimit = '';
+        if ($limit !== null) {
+            $limit = max(1, min((int) $limit, 50));
+            $queryLimit = "OFFSET 0 ROWS FETCH NEXT {$limit} ROWS ONLY";
+        }
 
         $query = "SELECT D1.*
                     FROM DISCIPLINAGR D1
@@ -35,8 +45,8 @@ class Graduacao extends GraduacaoReplicado
                     $queryLimit
         ";
 
-        $params['coddis'] = $coddis . '%';
+        $disciplinas = DB::fetchAll($query, ['coddis' => $coddis . '%']);
 
-        return DB::fetchAll($query, $params);
+        return is_array($disciplinas) ? $disciplinas : [];
     }
 }

--- a/src/Replicado/Graduacao.php
+++ b/src/Replicado/Graduacao.php
@@ -26,9 +26,8 @@ class Graduacao extends GraduacaoReplicado
         }
 
         $limit = max(1, min($limit, 50));
-        $queryLimit = "OFFSET 0 ROWS FETCH NEXT {$limit} ROWS ONLY";
 
-        $query = "SELECT D1.*
+        $query = "SELECT TOP {$limit} D1.*
                     FROM DISCIPLINAGR D1
                     INNER JOIN (
                         SELECT coddis, MAX(verdis) AS verdis
@@ -39,7 +38,6 @@ class Graduacao extends GraduacaoReplicado
                     AND D1.dtadtvdis IS NULL
                     AND D1.dtaatvdis IS NOT NULL
                     ORDER BY D1.coddis ASC
-                    $queryLimit
         ";
 
         $disciplinas = DB::fetchAll($query, ['coddis' => $coddis . '%']);


### PR DESCRIPTION
### Mudanças realizadas

1. **Normalização do termo de busca**

   O termo recebido é convertido para maiúsculas e tem espaços externos removidos.

   **Motivação:** códigos como `  stt      ` e `STT` devem produzir a mesma busca.

2. **Validação de caracteres**

   Somente letras e números são aceitos. Termos vazios ou contendo `%`, `_`, espaços internos e outros símbolos retornam uma lista vazia.

   **Motivação:** impedir que caracteres fornecidos pelo usuário funcionem como curingas SQL da cláusula `LIKE` e evitar consultas excessivamente abrangentes.

3. **Limite seguro no SQL**

    Quando um limite é informado via parâmetro na chamada do método procurarDisciplinas(), ele determina a quantidade máxima de disciplinas retornadas, desde que esteja entre 1 e 50.

    Exemplos:
    - Limite `37`: retorna no máximo 37 disciplinas.
    - Limite `10`: retorna no máximo 10 disciplinas.
    - Limite maior que `50`: utiliza 50.
    - Limite menor que `1`: utiliza 1.
    - Sem limite especificado: limite default de 50.

    **Motivação:** garantir que o limite inserido diretamente na consulta seja sempre um número inteiro válido e, quando informado, não ultrapasse 50 resultados.

4. **Contrato JSON consistente**

   Respostas vazias agora usam sempre:

   ```json
   {"results":[]}
   ```

   **Motivação:** manter o formato esperado pelo Select2 em entradas inválidas e quando o Replicado não está configurado.

5. **Filtragem de registros malformados**

   Registros sem `coddis` ou `nomdis` são ignorados.

   **Motivação:** impedir erros durante a montagem da resposta caso o Replicado devolva dados incompletos.

6. **Normalização dos resultados**

   Espaços externos são removidos do código e do nome antes da criação de `id` e `text`.

   **Motivação:** entregar dados consistentes ao Select2.

7. **Tratamento de falhas do Replicado**

   Exceções são registradas no log e o endpoint retorna HTTP `503` com uma lista vazia.

   **Motivação:** diferenciar indisponibilidade externa de erro interno da aplicação e evitar uma resposta HTML inesperada para o Select2.

8. **Retorno defensivo do método de consulta**

    `Graduacao::procurarDisciplinas()` retorna sempre um array, mesmo se `DB::fetchAll()` produzir um valor inesperado.

    **Motivação:** manter estável o tipo de retorno consumido pelo controller e por aplicações externas.